### PR TITLE
AB#38714 Set up end point for graph explorer application mode proxy

### DIFF
--- a/GraphExplorerAppModeService/GraphExplorerAppModeService.csproj
+++ b/GraphExplorerAppModeService/GraphExplorerAppModeService.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <UserSecretsId>dotnet-GraphExplorerAppModeService-10DEC1C0-DF4C-4EA8-B0A8-54951DB93792</UserSecretsId>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/GraphExplorerAppModeService/Interfaces/IGraphAppAuthProvider.cs
+++ b/GraphExplorerAppModeService/Interfaces/IGraphAppAuthProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GraphExplorerAppModeService.Interfaces
+{
+    interface IGraphAppAuthProvider
+    {
+    }
+}

--- a/GraphExplorerAppModeService/Interfaces/IGraphServiceClient.cs
+++ b/GraphExplorerAppModeService/Interfaces/IGraphServiceClient.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GraphExplorerAppModeService.Interfaces
+{
+    interface IGraphServiceClient
+    {
+    }
+}

--- a/GraphExplorerAppModeService/Services/GraphAppAuthProvider.cs
+++ b/GraphExplorerAppModeService/Services/GraphAppAuthProvider.cs
@@ -1,0 +1,19 @@
+﻿using GraphExplorerAppModeService.Interfaces;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace GraphExplorerAppModeService.Services
+{
+    public class GraphAppAuthProvider : IGraphAppAuthProvider
+    {
+        public GraphAppAuthProvider(IConfiguration configuration)
+        {
+
+        }
+    }
+}

--- a/GraphExplorerAppModeService/Services/GraphClientService.cs
+++ b/GraphExplorerAppModeService/Services/GraphClientService.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphExplorerAppModeService.Interfaces;
+using Microsoft.Extensions.Configuration;
+
+namespace GraphExplorerAppModeService.Services
+{
+    class GraphClientService : IGraphServiceClient
+    {
+        public GraphClientService(IConfiguration configuration)
+        {
+
+        }
+    }
+}

--- a/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
@@ -15,45 +15,46 @@ namespace GraphWebApi.Controllers
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpGet]
-        public async Task<IActionResult> GetAsync(string all)
+        public async Task<IActionResult> GetAsync(string all, [FromHeader] string Authorization)
         {
-            return await ProcessRequestAsync("GET", all, null).ConfigureAwait(false);
+            return await ProcessRequestAsync("GET", all, null, Authorization).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpPost]
-        public async Task<IActionResult> PostAsync(string all, [FromBody] object body)
+        public async Task<IActionResult> PostAsync(string all, [FromBody] object body, [FromHeader] string Authorization)
         {
-            return await ProcessRequestAsync("POST", all, body).ConfigureAwait(false);
+            return await ProcessRequestAsync("POST", all, body, Authorization).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpDelete]
-        public async Task<IActionResult> DeleteAsync(string all)
+        public async Task<IActionResult> DeleteAsync(string all, [FromHeader] string Authorization)
         {
-            return await ProcessRequestAsync("DELETE", all, null).ConfigureAwait(false);
+            return await ProcessRequestAsync("DELETE", all, null, Authorization).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpPut]
-        public async Task<IActionResult> PutAsync(string all, [FromBody] object body)
+        public async Task<IActionResult> PutAsync(string all, [FromBody] object body, [FromHeader] string Authorization)
         {
-            return await ProcessRequestAsync("PUT", all, body).ConfigureAwait(false);
+            return await ProcessRequestAsync("PUT", all, body, Authorization).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpPatch]
-        public async Task<IActionResult> PatchAsync(string all, [FromBody] object body)
+        public async Task<IActionResult> PatchAsync(string all, [FromBody] object body, [FromHeader] string Authorization)
         {
-            return await ProcessRequestAsync("PATCH", all, body).ConfigureAwait(false);
+            return await ProcessRequestAsync("PATCH", all, body, Authorization).ConfigureAwait(false);
         }
 
-        private async Task<IActionResult> ProcessRequestAsync(string method, string all, object content)
+        private async Task<IActionResult> ProcessRequestAsync(string method, string all, object content, string Authorizaton)
         {
+            
             return Ok();
         }
     }

--- a/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using GraphExplorerAppModeService.Interfaces;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GraphWebApi.Controllers
+{
+    [ApiController]
+    public class GraphExplorerAppModeController : ControllerBase
+    {
+        [Route("api/[controller]/{*all}")]
+        [Route("graphproxy/{*all}")]
+        [HttpGet]
+        public async Task<IActionResult> GetAsync(string all)
+        {
+            return await ProcessRequestAsync("GET", all, null).ConfigureAwait(false);
+        }
+
+        [Route("api/[controller]/{*all}")]
+        [Route("graphproxy/{*all}")]
+        [HttpPost]
+        public async Task<IActionResult> PostAsync(string all, [FromBody] object body)
+        {
+            return await ProcessRequestAsync("POST", all, body).ConfigureAwait(false);
+        }
+
+        [Route("api/[controller]/{*all}")]
+        [Route("graphproxy/{*all}")]
+        [HttpDelete]
+        public async Task<IActionResult> DeleteAsync(string all)
+        {
+            return await ProcessRequestAsync("DELETE", all, null).ConfigureAwait(false);
+        }
+
+        [Route("api/[controller]/{*all}")]
+        [Route("graphproxy/{*all}")]
+        [HttpPut]
+        public async Task<IActionResult> PutAsync(string all, [FromBody] object body)
+        {
+            return await ProcessRequestAsync("PUT", all, body).ConfigureAwait(false);
+        }
+
+        [Route("api/[controller]/{*all}")]
+        [Route("graphproxy/{*all}")]
+        [HttpPatch]
+        public async Task<IActionResult> PatchAsync(string all, [FromBody] object body)
+        {
+            return await ProcessRequestAsync("PATCH", all, body).ConfigureAwait(false);
+        }
+
+        private async Task<IActionResult> ProcessRequestAsync(string method, string all, object content)
+        {
+            return Ok();
+        }
+    }
+}

--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -61,6 +61,7 @@
     <ProjectReference Include="..\ChangesService\ChangesService.csproj" />
     <ProjectReference Include="..\CodeSnippetsReflection\CodeSnippetsReflection.csproj" />
     <ProjectReference Include="..\FileService\FileService.csproj" />
+    <ProjectReference Include="..\GraphExplorerAppModeService\GraphExplorerAppModeService.csproj" />
     <ProjectReference Include="..\GraphExplorerPermissionsService\GraphExplorerPermissionsService.csproj" />
     <ProjectReference Include="..\GraphExplorerSamplesService\GraphExplorerSamplesService.csproj" />
     <ProjectReference Include="..\OpenAPIService\OpenAPIService.csproj" />

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -58,6 +58,8 @@ namespace GraphWebApi
                            ValidAudience = Configuration["AzureAd:Audience"],
                            ValidIssuer = Configuration["AzureAd:Issuer"]
                        };
+                       // This is to allow local testing using postman
+                       // To be removed when merged into dev
                        option.Events = new JwtBearerEvents()
                        {
                            OnAuthenticationFailed = context =>

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -27,6 +27,7 @@ using Microsoft.Extensions.Options;
 using TelemetrySanitizerService;
 using OpenAPIService.Interfaces;
 using OpenAPIService;
+using System.Threading.Tasks;
 
 namespace GraphWebApi
 {
@@ -56,6 +57,14 @@ namespace GraphWebApi
                        {
                            ValidAudience = Configuration["AzureAd:Audience"],
                            ValidIssuer = Configuration["AzureAd:Issuer"]
+                       };
+                       option.Events = new JwtBearerEvents()
+                       {
+                           OnAuthenticationFailed = context =>
+                           {
+                               context.NoResult();
+                               return Task.FromResult(0);
+                           }
                        };
                    });
 

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -3,7 +3,11 @@
     "Instance": "https://login.microsoftonline.com/",
     "TenantId": "ENTER_TENANT_ID",
     "Audience": "ENTER_APP_ID_URI",
-    "Issuer": "ENTER_ISSUER_URI"
+    "Issuer": "ENTER_ISSUER_URI",
+    "ClientId": "YOUR_APP_ID_HERE",
+    "ClientSecret": "YOUR_APP_PASSWORD_HERE", 
+    "Scopes": "openid email profile offline_access",
+    "GraphResourceId": "https://graph.microsoft.com/"
   },
   "Logging": {
     "LogLevel": {
@@ -52,5 +56,8 @@
     "SampleQueries": "24",
     "Permissions": "24",
     "ChangeLog": "24"
+  },
+  "GEApplicationMode": {
+
   }
 }

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -43,6 +43,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UtilityService", "UtilitySe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UtilityService.Test", "UtilityService.Test\UtilityService.Test.csproj", "{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphExplorerAppModeService", "GraphExplorerAppModeService\GraphExplorerAppModeService.csproj", "{AF515BB3-08B5-41A1-80E6-4529670A6B1C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,10 @@ Global
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Overview

Created basic entry point for the new endpoint that will be called.
Created empty service classes for Authorization and Graph Client to be initialized for easier understanding of endpoint structure.


## Testing Instructions

* Run the repo 
* Set a break point in the new controller to whichever action endpoint you are testing (Ex: Line 20 for GET)
* Run the API locally
* Open postman and call the api with your choice of action with the endpoint '/graphproxy/{Add anything here}'
* Add an authorization code as a header 
* Send the request 
* You should see {Add anything here} as the 'all' parameter and the authorization code as the Authorization parameter



ADO: https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/06?workitem=38714