### PR TITLE
AB#38606 graph requests

### DIFF
--- a/GraphExplorerAppModeService/GraphExplorerAppModeService.csproj
+++ b/GraphExplorerAppModeService/GraphExplorerAppModeService.csproj
@@ -8,5 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.35.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.14.1" />
   </ItemGroup>
 </Project>

--- a/GraphExplorerAppModeService/Interfaces/IGraphAppAuthProvider.cs
+++ b/GraphExplorerAppModeService/Interfaces/IGraphAppAuthProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Graph;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +7,8 @@ using System.Threading.Tasks;
 
 namespace GraphExplorerAppModeService.Interfaces
 {
-    interface IGraphAppAuthProvider
+    public interface IGraphAppAuthProvider
     {
+        GraphServiceClient GetAuthenticatedGraphClient(string accessToken);
     }
 }

--- a/GraphExplorerAppModeService/Services/GraphAppAuthProvider.cs
+++ b/GraphExplorerAppModeService/Services/GraphAppAuthProvider.cs
@@ -1,8 +1,11 @@
 ﻿using GraphExplorerAppModeService.Interfaces;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Graph;
+using Microsoft.Identity.Web;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,9 +14,14 @@ namespace GraphExplorerAppModeService.Services
 {
     public class GraphAppAuthProvider : IGraphAppAuthProvider
     {
-        public GraphAppAuthProvider(IConfiguration configuration)
-        {
 
-        }
+        public GraphServiceClient GetAuthenticatedGraphClient(string accessToken) =>
+            new GraphServiceClient(new DelegateAuthenticationProvider(
+                async requestMessage =>
+                {
+                    // Append the access token to the request
+                    requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+                }));
     }
+
 }

--- a/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
@@ -9,6 +9,11 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Web;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using Microsoft.Graph;
+using System.Net;
+using Microsoft.Identity.Client;
+using System.Threading;
+using Microsoft.Extensions.Primitives;
 
 namespace GraphWebApi.Controllers
 {
@@ -16,13 +21,16 @@ namespace GraphWebApi.Controllers
     public class GraphExplorerAppModeController : ControllerBase
     {
         private readonly ITokenAcquisition tokenAcquisition;
-        public GraphExplorerAppModeController(ITokenAcquisition tokenAcquisition)
+        private readonly GraphServiceClient _graphServiceClient;
+        public GraphExplorerAppModeController(ITokenAcquisition tokenAcquisition, GraphServiceClient graphServiceClient)
         {
             this.tokenAcquisition = tokenAcquisition;
+            this._graphServiceClient = graphServiceClient;
         }
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpGet]
+        [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> GetAsync(string all)
         {
             return await ProcessRequestAsync("GET", all, null).ConfigureAwait(false);
@@ -36,12 +44,14 @@ namespace GraphWebApi.Controllers
         {
             // Acquire the access token.
             string scopes = "https://graph.microsoft.com/.default";
+
             return await tokenAcquisition.GetAccessTokenForAppAsync(scopes);
-        }
+        } 
 
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpPost]
+        [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> PostAsync(string all, [FromBody] object body)
         {
             return await ProcessRequestAsync("POST", all, body).ConfigureAwait(false);
@@ -52,20 +62,133 @@ namespace GraphWebApi.Controllers
         [HttpDelete]
         public async Task<IActionResult> DeleteAsync(string all)
         {
-            return await ProcessRequestAsync("DELETE", all, null).ConfigureAwait(false);
+            try
+            {
+                string accessToken = GetTokenAsync("").Result.ToString();
+                HttpClient httpClient = new HttpClient();
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+                var response = await httpClient.DeleteAsync("https://graph.microsoft.com/v1.0/teams/8248c7dd-f773-40a5-b090-19386856ced3/channels/19:cfc8004ddb25441b8be2b7c5da02967a@thread.tacv2");
+                response.EnsureSuccessStatusCode();
+                Console.WriteLine("http status code is ok");
+                Console.WriteLine(response.ReasonPhrase);
+                Console.WriteLine(response.Content);
+                return Ok(response.ReasonPhrase);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine("IT WENT INTO EXCEPTTTTTTTTT");
+                return new JsonResult(exception) { StatusCode = 404 };
+            }
+            return null;
         }
 
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpPut]
-        public async Task<IActionResult> PutAsync(string all, [FromBody] object body)
+        [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
+        public async Task<IActionResult> PutAsync(string all)
         {
-            return await ProcessRequestAsync("PUT", all, body).ConfigureAwait(false);
+            GraphServiceClient _graphServiceClient = new GraphServiceClient(new DelegateAuthenticationProvider(
+                async requestMessage =>
+                    {
+                        // Passing tenant ID to the sample auth provider to use as a cache key
+                        string accessToken = GetTokenAsync("").Result.ToString();
+                        // Append the access token to the request
+                        requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+                    }));
+
+            var qs = HttpContext.Request.QueryString;
+            Console.WriteLine(HttpContext);
+
+            var url = $"{GetBaseUrlWithoutVersion(_graphServiceClient)}/{all}{qs.ToUriComponent()}";
+
+            Console.WriteLine("IS IT IN HERE");
+
+            var request = new BaseRequest(url, _graphServiceClient, null)
+            {
+                Method = "DELETE",
+                ContentType = HttpContext.Request.ContentType,
+            };
+
+            var contentType = "application/json";
+            object content = null;
+            try
+            {
+                using (var response = await request.SendRequestAsync(content?.ToString(), CancellationToken.None , HttpCompletionOption.ResponseContentRead).ConfigureAwait(false))
+                {
+                    response.Content.Headers.TryGetValues("content-type", out var contentTypes);
+
+                    contentType = contentTypes?.FirstOrDefault() ?? contentType;
+
+                    var byteArrayContent = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    Console.WriteLine(byteArrayContent);
+                    return new HttpResponseMessageResult(ReturnHttpResponseMessage(HttpStatusCode.OK, contentType, new ByteArrayContent(byteArrayContent)));
+                }
+            }
+            catch (ServiceException ex)
+            {
+                return new HttpResponseMessageResult(ReturnHttpResponseMessage(ex.StatusCode, contentType, new StringContent(ex.Error.ToString())));
+            }
+        }
+
+        private static HttpResponseMessage ReturnHttpResponseMessage(HttpStatusCode httpStatusCode, string contentType, HttpContent httpContent)
+        {
+            var httpResponseMessage = new HttpResponseMessage(httpStatusCode)
+            {
+                Content = httpContent
+            };
+
+            try
+            {
+                httpResponseMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            }
+            catch
+            {
+                httpResponseMessage.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            }
+
+            return httpResponseMessage;
+        }
+
+        private string GetBaseUrlWithoutVersion(GraphServiceClient graphClient)
+        {
+            var baseUrl = graphClient.BaseUrl;
+            var index = baseUrl.LastIndexOf('/');
+            return baseUrl.Substring(0, index);
+        }
+
+        public class HttpResponseMessageResult : IActionResult
+        {
+            private readonly HttpResponseMessage _responseMessage;
+
+            public HttpResponseMessageResult(HttpResponseMessage responseMessage)
+            {
+                _responseMessage = responseMessage; // could add throw if null
+            }
+
+            public async Task ExecuteResultAsync(ActionContext context)
+            {
+                context.HttpContext.Response.StatusCode = (int)_responseMessage.StatusCode;
+
+                foreach (var header in _responseMessage.Headers)
+                {
+                    context.HttpContext.Response.Headers.TryAdd(header.Key, new StringValues(header.Value.ToArray()));
+                }
+
+                context.HttpContext.Response.ContentType = _responseMessage.Content.Headers.ContentType.ToString();
+
+                using (var stream = await _responseMessage.Content.ReadAsStreamAsync())
+                {
+                    await stream.CopyToAsync(context.HttpContext.Response.Body);
+                    await context.HttpContext.Response.Body.FlushAsync();
+                }
+            }
         }
 
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpPatch]
+        [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> PatchAsync(string all, [FromBody] object body)
         {
             return await ProcessRequestAsync("PATCH", all, body).ConfigureAwait(false);

--- a/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using Microsoft.Extensions.Primitives;
 using GraphExplorerAppModeService.Services;
 using GraphExplorerAppModeService.Interfaces;
+using Microsoft.Extensions.Configuration;
 
 namespace GraphWebApi.Controllers
 {
@@ -24,18 +25,21 @@ namespace GraphWebApi.Controllers
         private readonly IGraphAppAuthProvider _graphClient;
         private readonly ITokenAcquisition _tokenAcquisition;
 
-        public GraphExplorerAppModeController(ITokenAcquisition tokenAcquisition, IGraphAppAuthProvider graphServiceClient)
+        private readonly IConfiguration _config;
+
+        public GraphExplorerAppModeController(IConfiguration configuration, ITokenAcquisition tokenAcquisition, IGraphAppAuthProvider graphServiceClient)
         {
             this._graphClient = graphServiceClient;
             this._tokenAcquisition = tokenAcquisition;
+            this._config = configuration;
         }
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{tenantId}/{*all}")]
+        [Route("graphproxy/{*all}")]
         [HttpGet]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> GetAsync(string all, string tenantId)
         {
-            return await this.ProcessRequestAsync("GET", all, null, tenantId).ConfigureAwait(false);
+            return await this.ProcessRequestAsync("GET", all, null, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
 
         private async Task<string> GetTokenAsync(string tenantId)
@@ -48,29 +52,29 @@ namespace GraphWebApi.Controllers
 
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{tenantId}/{*all}")]
+        [Route("graphproxy/{*all}")]
         [HttpPost]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> PostAsync(string all, [FromBody] object body, string tenantId)
         {
-            return await ProcessRequestAsync("POST", all, body, tenantId).ConfigureAwait(false);
+            return await ProcessRequestAsync("POST", all, body, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{tenantId}/{*all}")]
+        [Route("graphproxy/{*all}")]
         [HttpDelete]
         public async Task<IActionResult> DeleteAsync(string all, string tenantId)
         {
-            return await ProcessRequestAsync("DELETE", all, null, tenantId).ConfigureAwait(false);
+            return await ProcessRequestAsync("DELETE", all, null, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{tenantId}/{*all}")]
+        [Route("graphproxy/{*all}")]
         [HttpPut]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> PutAsync(string all, [FromBody] object body, string tenantId)
         {
-            return await ProcessRequestAsync("PUT", all, body, tenantId).ConfigureAwait(false);
+            return await ProcessRequestAsync("PUT", all, body, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
 
         private string GetBaseUrlWithoutVersion(GraphServiceClient graphClient)
@@ -109,12 +113,12 @@ namespace GraphWebApi.Controllers
         }
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{tenantId}/{*all}")]
+        [Route("graphproxy/{*all}")]
         [HttpPatch]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> PatchAsync(string all, [FromBody] object body, string tenantId)
         {
-            return await ProcessRequestAsync("PATCH", all, body, tenantId).ConfigureAwait(false);
+            return await ProcessRequestAsync("PATCH", all, body, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
 
         private async Task<IActionResult> ProcessRequestAsync(string method, string all, object content, string tenantId)

--- a/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
@@ -37,7 +37,7 @@ namespace GraphWebApi.Controllers
         [Route("graphproxy/{*all}")]
         [HttpGet]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> GetAsync(string all, string tenantId)
+        public async Task<IActionResult> GetAsync(string all)
         {
             return await this.ProcessRequestAsync("GET", all, null, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
@@ -55,7 +55,7 @@ namespace GraphWebApi.Controllers
         [Route("graphproxy/{*all}")]
         [HttpPost]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> PostAsync(string all, [FromBody] object body, string tenantId)
+        public async Task<IActionResult> PostAsync(string all, [FromBody] object body)
         {
             return await ProcessRequestAsync("POST", all, body, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
@@ -63,7 +63,7 @@ namespace GraphWebApi.Controllers
         [Route("api/[controller]/{*all}")]
         [Route("graphproxy/{*all}")]
         [HttpDelete]
-        public async Task<IActionResult> DeleteAsync(string all, string tenantId)
+        public async Task<IActionResult> DeleteAsync(string all)
         {
             return await ProcessRequestAsync("DELETE", all, null, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
@@ -72,7 +72,7 @@ namespace GraphWebApi.Controllers
         [Route("graphproxy/{*all}")]
         [HttpPut]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> PutAsync(string all, [FromBody] object body, string tenantId)
+        public async Task<IActionResult> PutAsync(string all, [FromBody] object body)
         {
             return await ProcessRequestAsync("PUT", all, body, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }
@@ -116,7 +116,7 @@ namespace GraphWebApi.Controllers
         [Route("graphproxy/{*all}")]
         [HttpPatch]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> PatchAsync(string all, [FromBody] object body, string tenantId)
+        public async Task<IActionResult> PatchAsync(string all, [FromBody] object body)
         {
             return await ProcessRequestAsync("PATCH", all, body, _config.GetSection("AzureAd").GetSection("TenantId").Value).ConfigureAwait(false);
         }

--- a/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
-using GraphExplorerAppModeService.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,6 +14,7 @@ using Microsoft.Identity.Client;
 using System.Threading;
 using Microsoft.Extensions.Primitives;
 using GraphExplorerAppModeService.Services;
+using GraphExplorerAppModeService.Interfaces;
 
 namespace GraphWebApi.Controllers
 {
@@ -30,47 +30,47 @@ namespace GraphWebApi.Controllers
             this._tokenAcquisition = tokenAcquisition;
         }
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{*all}")]
+        [Route("graphproxy/{tenantId}/{*all}")]
         [HttpGet]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> GetAsync(string all)
+        public async Task<IActionResult> GetAsync(string all, string tenantId)
         {
-            return await this.ProcessRequestAsync("GET", all, null).ConfigureAwait(false);
+            return await this.ProcessRequestAsync("GET", all, null, tenantId).ConfigureAwait(false);
         }
 
-        private async Task<string> GetTokenAsync()
+        private async Task<string> GetTokenAsync(string tenantId)
         {
             // Acquire the access token.
             string scopes = "https://graph.microsoft.com/.default";
 
-            return await _tokenAcquisition.GetAccessTokenForAppAsync(scopes);
+            return await _tokenAcquisition.GetAccessTokenForAppAsync(scopes, tenantId, null);
         }
 
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{*all}")]
+        [Route("graphproxy/{tenantId}/{*all}")]
         [HttpPost]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> PostAsync(string all, [FromBody] object body)
+        public async Task<IActionResult> PostAsync(string all, [FromBody] object body, string tenantId)
         {
-            return await ProcessRequestAsync("POST", all, body).ConfigureAwait(false);
+            return await ProcessRequestAsync("POST", all, body, tenantId).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{*all}")]
+        [Route("graphproxy/{tenantId}/{*all}")]
         [HttpDelete]
-        public async Task<IActionResult> DeleteAsync(string all)
+        public async Task<IActionResult> DeleteAsync(string all, string tenantId)
         {
-            return await ProcessRequestAsync("DELETE", all, null).ConfigureAwait(false);
+            return await ProcessRequestAsync("DELETE", all, null, tenantId).ConfigureAwait(false);
         }
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{*all}")]
+        [Route("graphproxy/{tenantId}/{*all}")]
         [HttpPut]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> PutAsync(string all, [FromBody] object body)
+        public async Task<IActionResult> PutAsync(string all, [FromBody] object body, string tenantId)
         {
-            return await ProcessRequestAsync("PUT", all, body).ConfigureAwait(false);
+            return await ProcessRequestAsync("PUT", all, body, tenantId).ConfigureAwait(false);
         }
 
         private string GetBaseUrlWithoutVersion(GraphServiceClient graphClient)
@@ -109,17 +109,17 @@ namespace GraphWebApi.Controllers
         }
 
         [Route("api/[controller]/{*all}")]
-        [Route("graphproxy/{*all}")]
+        [Route("graphproxy/{tenantId}/{*all}")]
         [HttpPatch]
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
-        public async Task<IActionResult> PatchAsync(string all, [FromBody] object body)
+        public async Task<IActionResult> PatchAsync(string all, [FromBody] object body, string tenantId)
         {
-            return await ProcessRequestAsync("PATCH", all, body).ConfigureAwait(false);
+            return await ProcessRequestAsync("PATCH", all, body, tenantId).ConfigureAwait(false);
         }
 
-        private async Task<IActionResult> ProcessRequestAsync(string method, string all, object content)
+        private async Task<IActionResult> ProcessRequestAsync(string method, string all, object content, string tenantId)
         {
-            GraphServiceClient _graphServiceClient = _graphClient.GetAuthenticatedGraphClient(GetTokenAsync().Result.ToString());
+            GraphServiceClient _graphServiceClient = _graphClient.GetAuthenticatedGraphClient(GetTokenAsync(tenantId).Result.ToString());
 
             var qs = HttpContext.Request.QueryString;
 

--- a/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerAppModeController.cs
@@ -53,7 +53,6 @@ namespace GraphWebApi.Controllers
         [AuthorizeForScopes(Scopes = new[] { "https://graph.microsoft.com/.default" })]
         public async Task<IActionResult> PostAsync(string all, [FromBody] object body)
         {
-            Console.WriteLine(body);
             return await ProcessRequestAsync("POST", all, body).ConfigureAwait(false);
         }
 

--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -49,10 +49,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="5.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.35.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.14.1" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="1.14.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+    <PackageReference Include="MySql.Data" Version="8.0.25" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -51,6 +51,7 @@ namespace GraphWebApi
             services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
                 .AddMicrosoftIdentityWebApp(Configuration, "AzureAd")
                 .EnableTokenAcquisitionToCallDownstreamApi()
+                .AddMicrosoftGraph(Configuration.GetSection("GraphV1"))
                 .AddInMemoryTokenCaches();
             services.AddDistributedMemoryCache();
             services.AddAuthentication(option =>

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -30,6 +30,8 @@ using OpenAPIService;
 using System.Threading.Tasks;
 using Microsoft.Identity.Web;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using GraphExplorerAppModeService.Services;
+using GraphExplorerAppModeService.Interfaces;
 
 namespace GraphWebApi
 {
@@ -102,6 +104,7 @@ namespace GraphWebApi
 
             services.AddMemoryCache();
             services.AddSingleton<ISnippetsGenerator, SnippetsGenerator>();
+            services.AddSingleton<IGraphAppAuthProvider, GraphAppAuthProvider>();
             services.AddSingleton<IFileUtility, AzureBlobStorageUtility>();
             services.AddSingleton<IPermissionsStore, PermissionsStore>();
             services.AddSingleton<ISamplesStore, SamplesStore>();

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -43,7 +43,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UtilityService", "UtilitySe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UtilityService.Test", "UtilityService.Test\UtilityService.Test.csproj", "{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphExplorerAppModeService", "GraphExplorerAppModeService\GraphExplorerAppModeService.csproj", "{215188E9-27A7-4004-B6FA-5A1C0D5786BF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphExplorerAppModeService", "GraphExplorerAppModeService\GraphExplorerAppModeService.csproj", "{AF515BB3-08B5-41A1-80E6-4529670A6B1C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -131,10 +131,10 @@ Global
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF515BB3-08B5-41A1-80E6-4529670A6B1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -43,6 +43,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UtilityService", "UtilitySe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UtilityService.Test", "UtilityService.Test\UtilityService.Test.csproj", "{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphExplorerAppModeService", "GraphExplorerAppModeService\GraphExplorerAppModeService.csproj", "{215188E9-27A7-4004-B6FA-5A1C0D5786BF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,10 @@ Global
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F4A15DC-F4CD-415D-A62D-6B0D95ED25E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{215188E9-27A7-4004-B6FA-5A1C0D5786BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Overview

* Be able to run queries as an application and use resource-specific consent
* This is part of the proxy work flow
* Built off of #11 because this requires the token

### Demo


https://user-images.githubusercontent.com/47228306/126374095-51bef39d-5eb6-425b-9ca0-fa4cf140e079.mp4


## Testing Instructions
* Pull this branch
* Fill in the TenantId, ClientId, ClientSecret and AzureConnectionString inside `appsettings.json` (Note that you need to have the necessary rsc permissions in the app to run the queries)
* Open in Visual Studio
* Run in IIS Express
* The endpoint is `https://localhost:44399/graphproxy/{tenantId}/{graph api call suffix}`
* What you add to your api call is what is passed to `https://graph.microsoft.com/`. Eg. GET `https://localhost:44399/graphproxy/{tenantId}/v1.0/` will be calling GET `https://graph.microsoft.com/v1.0/ .  